### PR TITLE
support tag surround texts

### DIFF
--- a/src/findCommand.js
+++ b/src/findCommand.js
@@ -1,6 +1,6 @@
 import { scrollViewportToShowTarget } from '@ckeditor/ckeditor5-utils/src/dom/scroll';
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import { CURRENT_SEARCH_MARKER, isSameSearch, removeCurrentSearchMarker, removeSearchMarkers, SEARCH_MARKER,getText } from './utils';
+import { CURRENT_SEARCH_MARKER, getText, isSameSearch, removeCurrentSearchMarker, removeSearchMarkers, SEARCH_MARKER } from './utils';
 
 const DEFAULT_OPTIONS = {
 	findText: '',
@@ -28,7 +28,7 @@ export default class FindCommand extends Command {
 		return this._find( options.findText, options.increment );
     }
 
-    _find(searchText, increment){
+	_find( searchText, increment ) {
     	const editor = this.editor;
     	const model = editor.model;
     	let markers = Array.from( model.markers.getMarkersGroup( SEARCH_MARKER ) );
@@ -40,11 +40,10 @@ export default class FindCommand extends Command {
 		else {
 			this._resetStatus();
 			const root = model.document.getRoot();
-			// Create a range spanning over the entire root content:
-			
+
 			let counter = 0;
 			model.change( writer => {
-				for(let element of root.getChildren()){
+				for ( let element of root.getChildren() ) {
 
 					let text = getText(element);
 					const indices = getIndicesOf( searchText, text, false );

--- a/src/findCommand.js
+++ b/src/findCommand.js
@@ -1,6 +1,6 @@
 import { scrollViewportToShowTarget } from '@ckeditor/ckeditor5-utils/src/dom/scroll';
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import { CURRENT_SEARCH_MARKER, isSameSearch, removeCurrentSearchMarker, removeSearchMarkers, SEARCH_MARKER } from './utils';
+import { CURRENT_SEARCH_MARKER, isSameSearch, removeCurrentSearchMarker, removeSearchMarkers, SEARCH_MARKER,getText } from './utils';
 
 const DEFAULT_OPTIONS = {
 	findText: '',
@@ -46,28 +46,15 @@ export default class FindCommand extends Command {
 			model.change( writer => {
 				for(let element of root.getChildren()){
 
-					const children = Array.from(element.getChildren());
-					let startIndex = 0,start=null,end =null;
-					for(let child of children){
-						if(child.is('text')){
-							startIndex = searchSameText(child,searchText,startIndex,function(startIndex,endIndex){
-								console.log('matched',child.data,startIndex,endIndex,counter);
-								const label = SEARCH_MARKER + ':' + searchText + ':' + counter++;
-								if(!start){
-									start = writer.createPositionAt( child.parent, startIndex );
-								}
-								if(endIndex){
-									end = writer.createPositionAt( child.parent, endIndex );
-									const range = writer.createRange( start, end );
-									writer.addMarker( label, { range, usingOperation: false } )
-									start = null;
-									end = null;
-								}
-								
-							})
-						}
+					let text = getText(element);
+					const indices = getIndicesOf( searchText, text, false );
+					for ( const index of indices ) {
+						const label = SEARCH_MARKER + ':' + searchText + ':' + counter++;
+						const start = writer.createPositionAt( element, index );
+						const end = writer.createPositionAt( element, index + searchText.length );
+						const range = writer.createRange( start, end );
+						writer.addMarker( label, { range, usingOperation: false } );
 					}
-					// console.log(element);
 				}
 				// update markers variable after search
 				markers = Array.from( model.markers.getMarkersGroup( SEARCH_MARKER ) );

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,32 +27,19 @@ export function removeCurrentSearchMarker( model, writer ) {
 
 
 /**
- * 
- * @param {*} child model element
- * @param {string} searchText searchText
- * @param {number} startIndex the index of text2 to start search
- * @param {function} callBack the callBack func when complete a match
+ * return the whole text of the node without tags
+ * @param {*} node model node
+ * @returns {string} the whole text of the node
  */
- export function searchSameText(child,searchText,startIndex,callBack){
-    let matchIndex = startIndex;
-    let start = 0;
-    const text = child.data;
-    for(let i=0;i<text.length;i++){
-        // match over
-        if(!searchText[matchIndex]){
-            callBack && callBack(start,i);
-            matchIndex = 0;
-        }
-        if(text[i] === searchText[matchIndex]){
-            if(matchIndex == 0) start = i;
-            if(i<text.length-1){
-                matchIndex++;
-            }else{
-                return matchIndex;
-            }          
-        }else{
-            start = i;
-            matchIndex = 0;
+ export function getText(node){
+    let str = '';
+    if(node.is('text')){
+        str += node.data
+    }else{
+        const children = Array.from(node.getChildren());
+        for(const child of children){
+            str += getText(child)
         }
     }
+    return str
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,3 +24,35 @@ export function removeCurrentSearchMarker( model, writer ) {
         writer.removeMarker( currentSearchMarker );
     }
 }
+
+
+/**
+ * 
+ * @param {*} child model element
+ * @param {string} searchText searchText
+ * @param {number} startIndex the index of text2 to start search
+ * @param {function} callBack the callBack func when complete a match
+ */
+ export function searchSameText(child,searchText,startIndex,callBack){
+    let matchIndex = startIndex;
+    let start = 0;
+    const text = child.data;
+    for(let i=0;i<text.length;i++){
+        // match over
+        if(!searchText[matchIndex]){
+            callBack && callBack(start,i);
+            matchIndex = 0;
+        }
+        if(text[i] === searchText[matchIndex]){
+            if(matchIndex == 0) start = i;
+            if(i<text.length-1){
+                matchIndex++;
+            }else{
+                return matchIndex;
+            }          
+        }else{
+            start = i;
+            matchIndex = 0;
+        }
+    }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,15 +31,15 @@ export function removeCurrentSearchMarker( model, writer ) {
  * @param {*} node model node
  * @returns {string} the whole text of the node
  */
- export function getText(node){
+ export function getText( node ) {
     let str = '';
-    if(node.is('text')){
-        str += node.data
-    }else{
+    if ( node.is( 'text' ) ) {
+        str += node.data;
+    } else {
         const children = Array.from(node.getChildren());
-        for(const child of children){
-            str += getText(child)
+        for ( const child of children ) {
+            str += getText( child );
         }
     }
-    return str
+    return str;
 }


### PR DESCRIPTION
update the find method to support text with tags / attributes
eg: try to find `hello` in
```html
h<i>ell</i>o
```
now can find `hello` correctly